### PR TITLE
Feature 14 chartexpand

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,12 +13,14 @@
   "rules": {
     "no-unused-vars": "warn",
     "object-curly-newline": "off",
+    "react/jsx-curly-newline": "off",
     "react/jsx-one-expression-per-line": "off",
     "react/forbid-prop-types": "warn",
     "comma-dangle": "off",
     "operator-linebreak": "off",
     "prefer-arrow-callback": "warn",
     "no-confusing-arrow": "off",
-    "implicit-arrow-linebreak": "off"
+    "implicit-arrow-linebreak": "off",
+    "no-nested-ternary": "warn"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "prefer-arrow-callback": "warn",
     "no-confusing-arrow": "off",
     "implicit-arrow-linebreak": "off",
-    "no-nested-ternary": "warn"
+    "no-nested-ternary": "warn",
+    "indent": "off"
   }
 }

--- a/src/components/Minicharts.jsx
+++ b/src/components/Minicharts.jsx
@@ -186,7 +186,11 @@ function ScatterplotGDP({ data, xMetric, size }) {
               cx={xScale(d[xMetric])}
               cy={yScale(d.avgVal)}
               r={
-                Math.abs(d.avgVal) < 0.001 ? '0' : size === 'large' ? '3' : '1'
+                Math.abs(d.avgVal) < 0.001 || Math.abs(d[xMetric]) < 0.001
+                  ? '0'
+                  : size === 'large'
+                  ? '3'
+                  : '1'
               }
               fill="blue"
               //   onMouseMove={handleMouseMove}
@@ -304,7 +308,7 @@ export function PresentWorldSection({ data }) {
         </button>
         <SelectWrapper>
           <Select
-            defaultValue={{ value: xMetric, label: 'Average GDP Per Capita' }}
+            defaultValue={{ value: xMetric, label: xMetric }}
             options={xMetricOptions}
             onChange={(a) => setXMetric(a.value)}
           />
@@ -314,7 +318,7 @@ export function PresentWorldSection({ data }) {
             onChange={(a) => setMetricCategory(a.value)}
           />
           <Select
-            defaultValue={{ value: colorBy, label: 'Color by: Trend' }}
+            // defaultValue={{ value: colorBy, label: 'Color by: Trend' }}
             options={colorByOptions}
             onChange={(a) => setColorBy(a.value)}
           />
@@ -344,7 +348,7 @@ export function PresentWorldSection({ data }) {
     <SectionWrapper>
       <SelectWrapper>
         <Select
-          defaultValue={{ value: xMetric, label: 'Average GDP Per Capita' }}
+          defaultValue={{ value: xMetric, label: xMetric }}
           options={xMetricOptions}
           onChange={(a) => setXMetric(a.value)}
         />


### PR DESCRIPTION
Solves #14 onHover, arrow appears over every chart component and when you click it, all charts become small and horizontal scrolly and the bottom and the one you clicked is big. When you click on small charts in the scrolly, you remain on same page and clicked chart is now big- all makes sense. Filed a bug #20  on the dropdown label issue but that's a later problem

... did I already close this??